### PR TITLE
Fix examples according to package name

### DIFF
--- a/examples/random/main.rs
+++ b/examples/random/main.rs
@@ -1,4 +1,4 @@
-extern crate ssd1307fd;
+extern crate ssd1307fb;
 
 use embedded_graphics::{
     mono_font::{ascii::FONT_6X10, MonoTextStyle},
@@ -13,7 +13,7 @@ use embedded_graphics::{
 };
 
 fn main() -> Result<(), std::convert::Infallible> {
-    let mut display = ssd1307fd::Display::new("/dev/fb1").unwrap();
+    let mut display = ssd1307fb::Display::new("/dev/fb1").unwrap();
 
     // Create styles used by the drawing operations.
     let thin_stroke = PrimitiveStyle::with_stroke(BinaryColor::On, 1);

--- a/examples/rectangle/main.rs
+++ b/examples/rectangle/main.rs
@@ -1,4 +1,4 @@
-extern crate ssd1307fd;
+extern crate ssd1307fb;
 
 use embedded_graphics::{
     pixelcolor::BinaryColor,
@@ -11,7 +11,7 @@ use embedded_graphics::{
 };
 
 fn main() {
-    let mut display = ssd1307fd::Display::new("/dev/fb1").unwrap();
+    let mut display = ssd1307fb::Display::new("/dev/fb1").unwrap();
     let fill = PrimitiveStyle::with_fill(BinaryColor::On);
 
     // Draw a filled square


### PR DESCRIPTION
The package name has been changed from ssd1307fd to ssd1307fb, but it was missed to change the example code accordingly. As a result the example code did not compile anymore. This is now fixed.